### PR TITLE
Enhance CV with new sections

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,20 +1,24 @@
 import './App.css'
 import Header from './components/Header'
 import About from './components/About'
+import Skills from './components/Skills'
 import Experience from './components/Experience'
+import Education from './components/Education'
 import Projects from './components/Projects'
 import Contact from './components/Contact'
 
 function App() {
-    return (
-        <>
-            <Header />
-            <About />
-            <Experience />
-            <Projects />
-            <Contact />
-        </>
-    )
+  return (
+    <>
+      <Header />
+      <About />
+      <Skills />
+      <Experience />
+      <Education />
+      <Projects />
+      <Contact />
+    </>
+  )
 }
 
 export default App

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,12 +1,16 @@
+import Section from './Section'
+
 function About() {
-    return (
-        <section id="about" className="px-8 py-12 bg-white text-gray-800">
-            <h2 className="text-2xl font-semibold mb-4">About Me</h2>
-            <p>
-                I’m a passionate full stack developer with expertise in building scalable and user-centric web applications.
-            </p>
-        </section>
-    )
+  return (
+    <Section id="about" title="About Me" className="bg-white text-gray-800">
+      <p>
+        I’m a passionate full stack developer with over 9 years of experience
+        building scalable and user-centric applications. I enjoy turning complex
+        problems into simple, beautiful interfaces and efficient backend
+        services.
+      </p>
+    </Section>
+  )
 }
 
 export default About

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,9 +1,17 @@
+import Section from './Section'
+
 function Contact() {
-    return (
-        <section id="contact" className="px-8 py-12">
-            <h2 className="text-2xl font-semibold mb-4">Contact</h2>
-            <p>Coming soon...</p>
-        </section>
-    )
+  return (
+    <Section id="contact" title="Contact">
+      <p>
+        Feel free to reach out via{' '}
+        <a href="mailto:santosh@example.com" className="text-blue-600 underline">
+          santosh@example.com
+        </a>
+        .
+      </p>
+    </Section>
+  )
 }
+
 export default Contact

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -1,0 +1,25 @@
+import Section from './Section'
+import EducationItem from './EducationItem'
+
+function Education() {
+  const education = [
+    {
+      degree: 'B.Tech in Computer Science',
+      institution: 'State University',
+      period: '2010 - 2014'
+    }
+  ]
+
+  return (
+    <Section id="education" title="Education">
+      {education.map(item => (
+        <EducationItem
+          key={item.degree + item.institution}
+          {...item}
+        />
+      ))}
+    </Section>
+  )
+}
+
+export default Education

--- a/src/components/EducationItem.tsx
+++ b/src/components/EducationItem.tsx
@@ -1,0 +1,17 @@
+interface EducationItemProps {
+  degree: string
+  institution: string
+  period: string
+}
+
+function EducationItem({ degree, institution, period }: EducationItemProps) {
+  return (
+    <div className="mb-6 text-left">
+      <h3 className="text-xl font-semibold">{degree}</h3>
+      <span className="text-sm">{institution}</span>
+      <p className="text-sm text-gray-600">{period}</p>
+    </div>
+  )
+}
+
+export default EducationItem

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,9 +1,38 @@
+import Section from './Section'
+import ExperienceItem from './ExperienceItem'
+
 function Experience() {
-    return (
-        <section id="experience" className="px-8 py-12">
-            <h2 className="text-2xl font-semibold mb-4">Experience</h2>
-            <p>Coming soon...</p>
-        </section>
-    )
+  const experiences = [
+    {
+      role: 'Senior Full Stack Engineer',
+      company: 'Tech Corp',
+      period: '2021 - Present',
+      description:
+        'Leading the development of scalable web applications and mentoring junior developers.'
+    },
+    {
+      role: 'Full Stack Developer',
+      company: 'Innovate Labs',
+      period: '2017 - 2021',
+      description:
+        'Built and maintained cross-platform solutions using modern frameworks and cloud services.'
+    },
+    {
+      role: 'Software Engineer',
+      company: 'Startup XYZ',
+      period: '2014 - 2017',
+      description:
+        'Worked on both frontend and backend features for the company’s flagship product.'
+    }
+  ]
+
+  return (
+    <Section id="experience" title="Experience">
+      {experiences.map(exp => (
+        <ExperienceItem key={exp.role + exp.company} {...exp} />
+      ))}
+    </Section>
+  )
 }
+
 export default Experience

--- a/src/components/ExperienceItem.tsx
+++ b/src/components/ExperienceItem.tsx
@@ -1,0 +1,18 @@
+interface ExperienceItemProps {
+  role: string
+  company: string
+  period: string
+  description: string
+}
+
+function ExperienceItem({ role, company, period, description }: ExperienceItemProps) {
+  return (
+    <div className="mb-6 text-left">
+      <h3 className="text-xl font-semibold">{role} - {company}</h3>
+      <span className="text-sm text-gray-600">{period}</span>
+      <p className="mt-2">{description}</p>
+    </div>
+  )
+}
+
+export default ExperienceItem

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,30 @@
 function Header() {
-    return (
-        <header className="w-full bg-blue-900 text-white py-4 px-8">
-            <h1 className="text-3xl font-bold">Santosh Sagar</h1>
-            <p className="text-sm">Full Stack Software Developer</p>
-        </header>
-    )
+  const links = [
+    { href: '#about', label: 'About' },
+    { href: '#skills', label: 'Skills' },
+    { href: '#experience', label: 'Experience' },
+    { href: '#education', label: 'Education' },
+    { href: '#projects', label: 'Projects' },
+    { href: '#contact', label: 'Contact' }
+  ]
+
+  return (
+    <header className="w-full bg-blue-900 text-white py-4 px-8">
+      <h1 className="text-3xl font-bold">Santosh Sagar</h1>
+      <p className="text-sm">Full Stack Software Developer</p>
+      <nav className="mt-2">
+        <ul className="flex flex-wrap gap-4 justify-center text-sm">
+          {links.map(link => (
+            <li key={link.href}>
+              <a href={link.href} className="hover:underline">
+                {link.label}
+              </a>
+            </li>
+          ))}
+        </ul>
+      </nav>
+    </header>
+  )
 }
 
 export default Header

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,9 +1,33 @@
+import Section from './Section'
+
 function Projects() {
-    return (
-        <section id="projects" className="px-8 py-12">
-            <h2 className="text-2xl font-semibold mb-4">Projects</h2>
-            <p>Coming soon...</p>
-        </section>
-    )
+  const projects = [
+    {
+      name: 'Portfolio Website',
+      description: 'Personal portfolio built with React, Vite and Tailwind CSS.'
+    },
+    {
+      name: 'E-commerce Platform',
+      description: 'Full featured online shop with custom backend APIs.'
+    },
+    {
+      name: 'Real-time Chat App',
+      description: 'WebSocket powered chat application with notifications.'
+    }
+  ]
+
+  return (
+    <Section id="projects" title="Projects">
+      <ul className="space-y-4 text-left">
+        {projects.map(project => (
+          <li key={project.name}>
+            <h3 className="text-xl font-semibold">{project.name}</h3>
+            <p>{project.description}</p>
+          </li>
+        ))}
+      </ul>
+    </Section>
+  )
 }
+
 export default Projects

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -1,0 +1,19 @@
+import { ReactNode } from 'react'
+
+interface SectionProps {
+  id: string
+  title: string
+  children: ReactNode
+  className?: string
+}
+
+function Section({ id, title, children, className = '' }: SectionProps) {
+  return (
+    <section id={id} className={`px-8 py-12 ${className}`.trim()}>
+      <h2 className="text-2xl font-semibold mb-4">{title}</h2>
+      {children}
+    </section>
+  )
+}
+
+export default Section

--- a/src/components/SkillList.tsx
+++ b/src/components/SkillList.tsx
@@ -1,0 +1,17 @@
+interface SkillListProps {
+  skills: string[]
+}
+
+function SkillList({ skills }: SkillListProps) {
+  return (
+    <ul className="flex flex-wrap gap-2 justify-center">
+      {skills.map(skill => (
+        <li key={skill} className="bg-gray-200 px-3 py-1 rounded text-sm">
+          {skill}
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+export default SkillList

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -1,0 +1,24 @@
+import Section from './Section'
+import SkillList from './SkillList'
+
+function Skills() {
+  const skills = [
+    'JavaScript',
+    'TypeScript',
+    'React',
+    'Node.js',
+    'Express',
+    'SQL',
+    'MongoDB',
+    'Docker',
+    'AWS'
+  ]
+
+  return (
+    <Section id="skills" title="Skills">
+      <SkillList skills={skills} />
+    </Section>
+  )
+}
+
+export default Skills


### PR DESCRIPTION
## Summary
- create reusable `Section` component
- add components for skills, education, and experience
- update existing sections to use the reusable component
- include navigation links in the header
- show sample data for experience, projects, and skills

## Testing
- `npm run lint` *(fails: cannot find ESLint packages because network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_688427538cf883209541dd5a689a8ef9