### PR TITLE
Improve layout styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2,7 +2,6 @@
   max-width: 1280px;
   margin: 0 auto;
   padding: 2rem;
-  text-align: center;
 }
 
 .logo {

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -2,7 +2,7 @@ import Section from './Section'
 
 function Contact() {
   return (
-    <Section id="contact" title="Contact">
+    <Section id="contact" title="Contact" className="bg-gray-50">
       <p>
         Feel free to reach out via{' '}
         <a href="mailto:santosh@example.com" className="text-blue-600 underline">

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -11,7 +11,7 @@ function Education() {
   ]
 
   return (
-    <Section id="education" title="Education">
+    <Section id="education" title="Education" className="bg-gray-50">
       {education.map(item => (
         <EducationItem
           key={item.degree + item.institution}

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -27,7 +27,7 @@ function Experience() {
   ]
 
   return (
-    <Section id="experience" title="Experience">
+    <Section id="experience" title="Experience" className="bg-white">
       {experiences.map(exp => (
         <ExperienceItem key={exp.role + exp.company} {...exp} />
       ))}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -9,20 +9,24 @@ function Header() {
   ]
 
   return (
-    <header className="w-full bg-blue-900 text-white py-4 px-8">
-      <h1 className="text-3xl font-bold">Santosh Sagar</h1>
-      <p className="text-sm">Full Stack Software Developer</p>
-      <nav className="mt-2">
-        <ul className="flex flex-wrap gap-4 justify-center text-sm">
-          {links.map(link => (
-            <li key={link.href}>
-              <a href={link.href} className="hover:underline">
-                {link.label}
-              </a>
-            </li>
-          ))}
-        </ul>
-      </nav>
+    <header className="w-full bg-blue-900 text-white shadow-md">
+      <div className="max-w-5xl mx-auto flex flex-col items-center sm:flex-row sm:justify-between py-4 px-8">
+        <div className="text-center sm:text-left">
+          <h1 className="text-3xl font-bold">Santosh Sagar</h1>
+          <p className="text-sm">Full Stack Software Developer</p>
+        </div>
+        <nav className="mt-2 sm:mt-0">
+          <ul className="flex flex-wrap gap-4 justify-center sm:justify-end text-sm list-none">
+            {links.map(link => (
+              <li key={link.href}>
+                <a href={link.href} className="hover:underline">
+                  {link.label}
+                </a>
+              </li>
+            ))}
+          </ul>
+        </nav>
+      </div>
     </header>
   )
 }

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -17,7 +17,7 @@ function Projects() {
   ]
 
   return (
-    <Section id="projects" title="Projects">
+    <Section id="projects" title="Projects" className="bg-white">
       <ul className="space-y-4 text-left">
         {projects.map(project => (
           <li key={project.name}>

--- a/src/components/Section.tsx
+++ b/src/components/Section.tsx
@@ -9,7 +9,7 @@ interface SectionProps {
 
 function Section({ id, title, children, className = '' }: SectionProps) {
   return (
-    <section id={id} className={`px-8 py-12 ${className}`.trim()}>
+    <section id={id} className={`px-8 py-12 max-w-4xl mx-auto text-left ${className}`.trim()}>
       <h2 className="text-2xl font-semibold mb-4">{title}</h2>
       {children}
     </section>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -15,7 +15,7 @@ function Skills() {
   ]
 
   return (
-    <Section id="skills" title="Skills">
+    <Section id="skills" title="Skills" className="bg-gray-50">
       <SkillList skills={skills} />
     </Section>
   )

--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,6 @@ html, body, #root {
   width: 100%;
   height: 100%;
   font-family: system-ui, sans-serif;
-  background-color: white;
+  background-color: #f8fafc;
   color: black;
 }


### PR DESCRIPTION
## Summary
- clean up global centering styles
- add flex layout for header navigation
- add alternating backgrounds for content sections
- keep sections centered with a max width
- refine header container and remove list bullets
- set light background color for the page

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6885113c3d488320a3929515fcb317b5